### PR TITLE
feat: Add GitHub Action for Crystallize imports

### DIFF
--- a/.github/workflows/import-crystallize.yml
+++ b/.github/workflows/import-crystallize.yml
@@ -1,0 +1,27 @@
+name: Import to Crystallize
+
+on:
+  workflow_dispatch:  # Manual trigger from GitHub UI
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run import script
+        run: node scripts/crystallize-import/import.js
+        env:
+          TENANT_ID: ${{ secrets.CRYSTALLIZE_TENANT_ID }}
+          ACCESS_TOKEN_ID: ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_ID }}
+          ACCESS_TOKEN_SECRET: ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_SECRET }}


### PR DESCRIPTION
This commit introduces a GitHub Action workflow to automate the import process to Crystallize.

The workflow (`.github/workflows/import-crystallize.yml`) can be triggered manually via the GitHub UI.

It performs the following steps:
- Checks out the repository.
- Sets up Node.js version 20.
- Installs npm dependencies.
- Runs the `scripts/crystallize-import/import.js` script.

The import script utilizes the following secrets, which need to be configured in your repository's Actions secrets settings:
- `CRYSTALLIZE_TENANT_ID`
- `CRYSTALLIZE_ACCESS_TOKEN_ID`
- `CRYSTALLIZE_ACCESS_TOKEN_SECRET`