### PR TITLE
I've made some adjustments to the import script.

### DIFF
--- a/.github/workflows/import-crystallize.yml
+++ b/.github/workflows/import-crystallize.yml
@@ -1,0 +1,30 @@
+name: Import to Crystallize
+
+on:
+  workflow_dispatch:  # Manual trigger from GitHub UI
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies for import script
+        working-directory: ./scripts/crystallize-import
+        run: npm install
+
+
+      - name: Run import script
+        working-directory: ./scripts/crystallize-import
+        run: node import.js
+        env:
+          TENANT_ID: ${{ secrets.CRYSTALLIZE_TENANT_ID }}
+          ACCESS_TOKEN_ID: ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_ID }}
+          ACCESS_TOKEN_SECRET: ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_SECRET }}

--- a/scripts/crystallize-import/import.js
+++ b/scripts/crystallize-import/import.js
@@ -2,7 +2,9 @@ import { Bootstrapper } from '@crystallize/import-utilities';
 import spec from './crystallize_import_spec_tools_products.json' assert { type: 'json' };
 import dotenv from 'dotenv';
 
-dotenv.config();
+if (process.env.CI !== 'true') {
+  dotenv.config();
+}
 
 if (!process.env.TENANT_ID || !process.env.ACCESS_TOKEN_ID || !process.env.ACCESS_TOKEN_SECRET) {
   console.error('Error: Missing Crystallize credentials in .env file. Please ensure TENANT_ID, ACCESS_TOKEN_ID, and ACCESS_TOKEN_SECRET are set.');


### PR DESCRIPTION
I modified `scripts/crystallize-import/import.js` so that it only attempts to load environment variables from a `.env` file if it's not running in a CI environment.

This change ensures that when the script is run in a CI environment like GitHub Actions, it will rely on environment variables provided directly by the CI system (e.g., from GitHub secrets). This makes things more robust and follows best practices for handling configuration in different environments.

The main problem with missing credentials was fixed by correcting the `CRYSTALLIZE_TENANT_ID` secret value. This update adds an extra safeguard for how `.env` files are handled.