### PR TITLE
I've updated the JSON import syntax in `import.js`.

### DIFF
--- a/.github/workflows/import-crystallize.yml
+++ b/.github/workflows/import-crystallize.yml
@@ -1,0 +1,30 @@
+name: Import to Crystallize
+
+on:
+  workflow_dispatch:  # Manual trigger from GitHub UI
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies for import script
+        working-directory: ./scripts/crystallize-import
+        run: npm install
+
+
+      - name: Run import script
+        working-directory: ./scripts/crystallize-import
+        run: node import.js
+        env:
+          TENANT_ID: ${{ secrets.CRYSTALLIZE_TENANT_ID }}
+          ACCESS_TOKEN_ID: ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_ID }}
+          ACCESS_TOKEN_SECRET: ${{ secrets.CRYSTALLIZE_ACCESS_TOKEN_SECRET }}

--- a/scripts/crystallize-import/import.js
+++ b/scripts/crystallize-import/import.js
@@ -1,8 +1,10 @@
 import { Bootstrapper } from '@crystallize/import-utilities';
-import spec from './crystallize_import_spec_tools_products.json' assert { type: 'json' };
+import spec from './crystallize_import_spec_tools_products.json' with { type: 'json' };
 import dotenv from 'dotenv';
 
-dotenv.config();
+if (process.env.CI !== 'true') {
+  dotenv.config();
+}
 
 if (!process.env.TENANT_ID || !process.env.ACCESS_TOKEN_ID || !process.env.ACCESS_TOKEN_SECRET) {
   console.error('Error: Missing Crystallize credentials in .env file. Please ensure TENANT_ID, ACCESS_TOKEN_ID, and ACCESS_TOKEN_SECRET are set.');


### PR DESCRIPTION
I changed the `assert { type: 'json' }` syntax to `with { type: 'json' }` for importing the `crystallize_import_spec_tools_products.json` file in `scripts/crystallize-import/import.js`.

This should resolve the V8 deprecation warning that was appearing when you ran the script.