### PR TITLE
fix: Exclude crystallize-import-app from Next.js TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "crystallize-import-app"]
 }


### PR DESCRIPTION
The Vercel deployment was failing due to the Next.js build process attempting to type-check the `crystallize-import-app` directory. This app is a separate Remix application with its own dependencies (including @crystallize/schema) and build process.

This commit updates the root `tsconfig.json` to add `crystallize-import-app` to the `exclude` array. This prevents the Next.js TypeScript compiler from processing files within that directory, resolving the build error.