### PR TITLE
Fix: Remove width/height from GraphQL image queries

### DIFF
--- a/lib/bff/index.ts
+++ b/lib/bff/index.ts
@@ -41,8 +41,6 @@ const PRODUCT_COMMON_QUERY_FIELDS = `
     images {
       url
       altText
-      width
-      height
     }
     attributes { attribute value } # Assuming attributes are needed for options
   }
@@ -378,7 +376,7 @@ export async function getCollection(
                 ... on RichTextContent { json }
               }
             }
-            images(first: 1) { url altText width height }
+            images(first: 1) { url altText }
             meta: metaConnection(first: 5) { edges { node { key value } } }
           }
           # Specific types if you want to query differently based on type
@@ -937,7 +935,7 @@ const DESCENDANT_PRODUCTS_QUERY = /* GraphQL */ `
         }
         productImageFromComponent: component(id: "product-image") {
           content {
-            ... on ImageContent { images { url altText width height } }
+            ... on ImageContent { images { url altText } }
           }
         }
         components {
@@ -945,7 +943,7 @@ const DESCENDANT_PRODUCTS_QUERY = /* GraphQL */ `
           name
           type
           content {
-            ... on ImageContent { images { url altText width height } }
+            ... on ImageContent { images { url altText } }
             ... on NumericContent { number }
             ... on SingleLineContent { text }
           }
@@ -964,7 +962,7 @@ const DESCENDANT_PRODUCTS_QUERY = /* GraphQL */ `
           }
           productImageFromComponent: component(id: "product-image") {
             content {
-              ... on ImageContent { images { url altText width height } }
+              ... on ImageContent { images { url altText } }
             }
           }
           components {
@@ -972,7 +970,7 @@ const DESCENDANT_PRODUCTS_QUERY = /* GraphQL */ `
             name
             type
             content {
-              ... on ImageContent { images { url altText width height } }
+              ... on ImageContent { images { url altText } }
               ... on NumericContent { number }
               ... on SingleLineContent { text }
             }
@@ -991,7 +989,7 @@ const DESCENDANT_PRODUCTS_QUERY = /* GraphQL */ `
             }
             productImageFromComponent: component(id: "product-image") {
               content {
-                ... on ImageContent { images { url altText width height } }
+                ... on ImageContent { images { url altText } }
               }
             }
             components {
@@ -999,7 +997,7 @@ const DESCENDANT_PRODUCTS_QUERY = /* GraphQL */ `
               name
               type
               content {
-                ... on ImageContent { images { url altText width height } }
+                ... on ImageContent { images { url altText } }
                 ... on NumericContent { number }
                 ... on SingleLineContent { text }
               }
@@ -1018,7 +1016,7 @@ const DESCENDANT_PRODUCTS_QUERY = /* GraphQL */ `
               }
               productImageFromComponent: component(id: "product-image") {
                 content {
-                  ... on ImageContent { images { url altText width height } }
+                  ... on ImageContent { images { url altText } }
                 }
               }
               components {
@@ -1026,7 +1024,7 @@ const DESCENDANT_PRODUCTS_QUERY = /* GraphQL */ `
                 name
                 type
                 content {
-                  ... on ImageContent { images { url altText width height } }
+                  ... on ImageContent { images { url altText } }
                   ... on NumericContent { number }
                   ... on SingleLineContent { text }
                 }


### PR DESCRIPTION
Resolves a build error caused by GraphQL validation failing on 'width' and 'height' fields for the Image type. The live API schema for the Crystallize tenant appears to not support these fields as previously expected.

Changes made:
- Modified PRODUCT_COMMON_QUERY_FIELDS to remove width and height from variant images.
- Modified DESCENDANT_PRODUCTS_QUERY to remove width and height from images within components (e.g., productImageFromComponent, generic components).
- Modified the getCollection query to remove width and height from images fetched directly for Item types.

Data transformers already use fallbacks (e.g., `|| 0`) for width/height, ensuring that components relying on these values will not break and can use their own fallbacks or rely on Next/Image's `fill` prop. The build now passes the GraphQL validation stage.